### PR TITLE
chore: add .gitignore for Java/Android project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,26 @@
-*.iml
-.gradle
-/local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
-.DS_Store
-/build
-/captures
-.externalNativeBuild
-.cxx
+# Android / Gradle
+.gradle/
+build/
 local.properties
+*.iml
+.idea/
+*.apk
+*.aab
+*.dex
+*.class
+*.log
+
+# Java
+*.jar
+*.war
+*.nar
+*.ear
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+*.swp
+*.swo


### PR DESCRIPTION
Se agrega un archivo `.gitignore` estándar para proyectos Java/Android.
Esto evita que se suban al repositorio archivos generados (build, .gradle, .idea, etc.),
manteniendo el repositorio limpio y evitando conflictos innecesarios.

Cambios:
- Creación de `.gitignore` con reglas para Android Studio, Gradle, Java, y archivos del sistema.